### PR TITLE
feat: better support for XDG Base Directory

### DIFF
--- a/src/UserSettings.py
+++ b/src/UserSettings.py
@@ -10,21 +10,24 @@ import os
 from configparser import ConfigParser
 from pathlib import Path
 
+import gi
+
+gi.require_version("GLib", "2.0")
+from gi.repository import GLib
+
 
 class UserSettings(object):
     def __init__(self):
-        self.xdg_config_dir = os.environ.get("XDG_CONFIG_HOME", str(Path.home()) + "/.config")
-
         self.default_update_interval = 86400  # daily
         self.default_update_lastupdate = 0
 
         self.default_autostart = True
         self.default_notifications = True
 
-        self.configdir = self.xdg_config_dir + "/pardus/pardus-update/"
+        self.configdir = "{}/pardus/pardus-update/".format(GLib.get_user_config_dir())
         self.configfile = "settings.ini"
 
-        self.autostartdir = self.xdg_config_dir + "/autostart/"
+        self.autostartdir = "{}/autostart/".format(GLib.get_user_config_dir())
         self.autostartfile = "tr.org.pardus.update-autostart.desktop"
 
         self.config = ConfigParser(strict=False)

--- a/src/UserSettings.py
+++ b/src/UserSettings.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 class UserSettings(object):
     def __init__(self):
-        self.userhome = str(Path.home())
+        self.xdg_config_dir = os.environ.get("XDG_CONFIG_HOME", str(Path.home()) + "/.config")
 
         self.default_update_interval = 86400  # daily
         self.default_update_lastupdate = 0
@@ -21,10 +21,10 @@ class UserSettings(object):
         self.default_autostart = True
         self.default_notifications = True
 
-        self.configdir = self.userhome + "/.config/pardus/pardus-update/"
+        self.configdir = self.xdg_config_dir + "/pardus/pardus-update/"
         self.configfile = "settings.ini"
 
-        self.autostartdir = self.userhome + "/.config/autostart/"
+        self.autostartdir = self.xdg_config_dir + "/autostart/"
         self.autostartfile = "tr.org.pardus.update-autostart.desktop"
 
         self.config = ConfigParser(strict=False)


### PR DESCRIPTION
This PR removes the hardcoded path for the user configuration directory (`$HOME/.config/`) and instead uses the environment variable XDG_CONFIG_HOME. This allows users to have more control over where the configuration files are stored.