### PR TITLE
Fixed the tray icon and notifications in KDE Plasma 

### DIFF
--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -2645,7 +2645,7 @@ class Notification(GObject.GObject):
             Notify.uninit()
         Notify.init(_("Pardus Update"))
         self.notification = Notify.Notification.new(summary, body, icon)
-        self.notification.set_hint("desktop_entry", GLib.Variant("s", appid))
+        self.notification.set_hint("desktop-entry", GLib.Variant("s", appid))
         if not only_info:
             self.notification.set_timeout(Notify.EXPIRES_NEVER)
             self.notification.add_action('update', _('Update'), self.update_callback)

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -454,7 +454,7 @@ class MainWindow(object):
         self.icon_inprogress = "pardus-update-inprogress-symbolic" if system_wide else "media-playlist-repeat-symbolic"
         self.icon_error = "pardus-update-error-symbolic" if system_wide else "security-low-symbolic"
 
-        if not xfce_desktop:
+        if gnome_desktop:
             self.icon_available = "software-update-available-symbolic"
             self.icon_normal = "security-medium-symbolic"
             self.icon_inprogress = "media-playlist-repeat-symbolic"

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -2643,8 +2643,9 @@ class Notification(GObject.GObject):
         self.appid = appid
         if Notify.is_initted():
             Notify.uninit()
-        Notify.init(appid)
+        Notify.init(_("Pardus Update"))
         self.notification = Notify.Notification.new(summary, body, icon)
+        self.notification.set_hint("desktop_entry", GLib.Variant("s", appid))
         if not only_info:
             self.notification.set_timeout(Notify.EXPIRES_NEVER)
             self.notification.add_action('update', _('Update'), self.update_callback)


### PR DESCRIPTION
# Description

This PR improves pardus-update's compatibility with KDE Plasma. 

## Fix tray icon on KDE
The tray icon was invisible because the app was trying to select an adwaita icon on KDE Plasma environment. This issue was solved by changing the negative `if not xfce_desktop:` check to a positive `if gnome_desktop:` check.

| Before | After |
| :---: | :---: |
| <img width="306" height="268" alt="broken_tray_icon" src="https://github.com/user-attachments/assets/210572f1-cdd9-41a8-8ce0-f8763f6ca6eb" /> | <img width="306" height="268" alt="fixed_tray_icon" src="https://github.com/user-attachments/assets/b381e02b-e00a-466c-8979-bbf6dd35502b" /> |

---

## Fix notifications on KDE
Also the app's notifications were not working properly in KDE Plasma due to Plasma not detecting the correct application information. Solved this issue by adding a hint to the notification object, indicating that it is a desktop entry. 

| Before | After |
| :---: | :---: |
| <img width="407" height="157" alt="broken_notification" src="https://github.com/user-attachments/assets/593b20bd-b4c9-4051-99c5-b6a30b256c28" /> | <img width="403" height="158" alt="fixed_notfication" src="https://github.com/user-attachments/assets/d0d3282f-a21a-4f38-83e6-122b65f7c8e2" /> |

---

# Testing 

I have tested this PR on KDE Plasma as well as the existing Pardus desktop environments. No bugs or faults were detected and i have uploaded the screenshots below.

- [x] **KDE Plasma** (both the notifications and tray icons are working properly)
- [x] **XFCE** (no changes to ui)
- [x] **GNOME** (no changes to ui)

**xfce notification after update:**
<img width="252" height="115" alt="xfce_notification_after" src="https://github.com/user-attachments/assets/394e9c34-725f-4183-a76f-fa8f5d7ce981" />

**gnome notification after update:**
<img width="532" height="100" alt="image" src="https://github.com/user-attachments/assets/0478a797-4cd6-4ed8-9bb7-7055fa8bc948" />