### PR TITLE
Improve KDE Plasma icon and notification compatibility 

### DIFF
--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -55,6 +55,9 @@ xfce_desktop = False
 if "xfce" in getenv("SESSION").lower() or "xfce" in getenv("XDG_CURRENT_DESKTOP").lower():
     xfce_desktop = True
 
+kde_desktop = False
+if "kde" in getenv("SESSION").lower() or "kde" in getenv("XDG_CURRENT_DESKTOP").lower():
+    kde_desktop = True
 
 class MainWindow(object):
     def __init__(self, application):
@@ -454,9 +457,15 @@ class MainWindow(object):
         self.icon_inprogress = "pardus-update-inprogress-symbolic" if system_wide else "media-playlist-repeat-symbolic"
         self.icon_error = "pardus-update-error-symbolic" if system_wide else "security-low-symbolic"
 
-        if not xfce_desktop:
+        if gnome_desktop:
             self.icon_available = "software-update-available-symbolic"
             self.icon_normal = "security-medium-symbolic"
+            self.icon_inprogress = "media-playlist-repeat-symbolic"
+            self.icon_error = "security-low-symbolic"
+
+        if kde_desktop:
+            self.icon_available = "system-software-update-symbolic"
+            self.icon_normal = "security-high-symbolic"
             self.icon_inprogress = "media-playlist-repeat-symbolic"
             self.icon_error = "security-low-symbolic"
 

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -42,22 +42,36 @@ locale.bindtextdomain('pardus-update', '/usr/share/locale')
 locale.textdomain('pardus-update')
 
 
-def getenv(str):
-    env = os.environ.get(str)
-    return env if env else ""
+def getenv(name):
+    return os.environ.get(name, "").lower()
 
 
-gnome_desktop = False
-if "gnome" in getenv("SESSION").lower() or "gnome" in getenv("XDG_CURRENT_DESKTOP").lower():
-    gnome_desktop = True
+desktop_env = f"{getenv('SESSION')} {getenv('XDG_CURRENT_DESKTOP')}"
 
-xfce_desktop = False
-if "xfce" in getenv("SESSION").lower() or "xfce" in getenv("XDG_CURRENT_DESKTOP").lower():
-    xfce_desktop = True
+xfce_desktop = "xfce" in desktop_env
+kde_desktop = "kde" in desktop_env
 
-kde_desktop = False
-if "kde" in getenv("SESSION").lower() or "kde" in getenv("XDG_CURRENT_DESKTOP").lower():
-    kde_desktop = True
+ICONS_PARDUS = {
+    "available": "pardus-update-available-symbolic",
+    "normal": "pardus-update-symbolic",
+    "inprogress": "pardus-update-inprogress-symbolic",
+    "error": "pardus-update-error-symbolic",
+}
+
+ICONS_GENERIC = {
+    "available": "software-update-available-symbolic",
+    "normal": "security-medium-symbolic",
+    "inprogress": "media-playlist-repeat-symbolic",
+    "error": "security-low-symbolic",
+}
+
+ICONS_KDE = {
+    "available": "system-software-update-symbolic",
+    "normal": "security-high-symbolic",
+    "inprogress": "media-playlist-repeat-symbolic",
+    "error": "security-low-symbolic",
+}
+
 
 class MainWindow(object):
     def __init__(self, application):
@@ -452,22 +466,21 @@ class MainWindow(object):
 
     def define_variables(self):
         system_wide = "usr/share" in os.path.dirname(os.path.abspath(__file__))
-        self.icon_available = "pardus-update-available-symbolic" if system_wide else "software-update-available-symbolic"
-        self.icon_normal = "pardus-update-symbolic" if system_wide else "security-medium-symbolic"
-        self.icon_inprogress = "pardus-update-inprogress-symbolic" if system_wide else "media-playlist-repeat-symbolic"
-        self.icon_error = "pardus-update-error-symbolic" if system_wide else "security-low-symbolic"
+        
+        icons = ICONS_PARDUS if system_wide else ICONS_GENERIC
 
-        if gnome_desktop:
-            self.icon_available = "software-update-available-symbolic"
-            self.icon_normal = "security-medium-symbolic"
-            self.icon_inprogress = "media-playlist-repeat-symbolic"
-            self.icon_error = "security-low-symbolic"
+        # GNOME, Cinnamon, COSMIC, MATE, ...
+        if not xfce_desktop:
+            icons = ICONS_GENERIC
 
+        # KDE override
         if kde_desktop:
-            self.icon_available = "system-software-update-symbolic"
-            self.icon_normal = "security-high-symbolic"
-            self.icon_inprogress = "media-playlist-repeat-symbolic"
-            self.icon_error = "security-low-symbolic"
+            icons = ICONS_KDE
+
+        self.icon_available = icons["available"]
+        self.icon_normal = icons["normal"]
+        self.icon_inprogress = icons["inprogress"]
+        self.icon_error = icons["error"]
 
         self.autoupdate_glibid = None
         self.autoupdate_monitoring_glibid = None

--- a/src/MainWindow.py
+++ b/src/MainWindow.py
@@ -2652,8 +2652,9 @@ class Notification(GObject.GObject):
         self.appid = appid
         if Notify.is_initted():
             Notify.uninit()
-        Notify.init(appid)
+        Notify.init(_("Pardus Update"))
         self.notification = Notify.Notification.new(summary, body, icon)
+        self.notification.set_hint("desktop-entry", GLib.Variant("s", appid))
         if not only_info:
             self.notification.set_timeout(Notify.EXPIRES_NEVER)
             self.notification.add_action('update', _('Update'), self.update_callback)


### PR DESCRIPTION
# Description

This PR improves pardus-update's compatibility with KDE Plasma. 

## Fix tray icons on KDE
The tray icon was invisible because the app was trying to select an adwaita icon on KDE Plasma environment. This issue was solved by changing the negative `if not xfce_desktop:` check to a positive `if gnome_desktop:` check and adding a `if kde_desktop` check.

| Before | After |
| :---: | :---: |
| <img width="306" height="268" alt="broken_tray_icon" src="https://github.com/user-attachments/assets/210572f1-cdd9-41a8-8ce0-f8763f6ca6eb" /> | <img width="353" height="261" alt="image" src="https://github.com/user-attachments/assets/2b7d01db-5ce7-4517-83f8-01ae50f0c063" />|

---

## Fix notifications on KDE
Also the app's notifications were not working properly in KDE Plasma due to Plasma not detecting the correct application information. Solved this issue by adding a hint to the notification object, indicating that it is a desktop entry. 

| Before | After |
| :---: | :---: |
| <img width="407" height="157" alt="broken_notification" src="https://github.com/user-attachments/assets/593b20bd-b4c9-4051-99c5-b6a30b256c28" /> |<img width="402" height="159" alt="WhatsApp Image 2026-05-10 at 20 03 48" src="https://github.com/user-attachments/assets/81f1a31d-7a36-4bb4-b285-9c87353ac65d" />|

---

# Testing 

I have tested this PR on KDE Plasma as well as the existing Pardus desktop environments. No bugs or faults were detected and i have uploaded the screenshots below.

- [x] **KDE Plasma** (both the notifications and tray icons are working properly)
- [x] **XFCE** (no changes to ui)
- [x] **GNOME** (no changes to ui)

**xfce notification after update:**
<img width="252" height="115" alt="xfce_notification_after" src="https://github.com/user-attachments/assets/394e9c34-725f-4183-a76f-fa8f5d7ce981" />

**gnome notification after update:**
<img width="532" height="100" alt="image" src="https://github.com/user-attachments/assets/0478a797-4cd6-4ed8-9bb7-7055fa8bc948" />